### PR TITLE
Fix hydra-core requirement to version >=1.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ requirements = {
         "pyworld>=0.2.12",
         "sprocket-vc",
         "protobuf<=3.19.0",
-        "hydra-core>=1.1",
+        "hydra-core>=1.2",
     ],
     "setup": [
         "numpy",


### PR DESCRIPTION
Otherwise I got

```
Key 'chdir' not in 'JobConf'
    full_key: hydra.job.chdir
    reference_type=JobConf
    object_type=JobConf

Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace.
```

Or one can also consider writing code that should work with hydra v1.1.x but that would require a few more fixes.